### PR TITLE
Dispose UDP resources on stop

### DIFF
--- a/XPlaneConnector/XPlaneConnector/XPlaneConnector.cs
+++ b/XPlaneConnector/XPlaneConnector/XPlaneConnector.cs
@@ -118,9 +118,12 @@ namespace XPlaneConnector
                     Task.WaitAll(new[] { serverTask, observerTask }, timeout);
                     ts.Dispose();
                     ts = null;
-
-                    client.Close();
                 }
+
+                server?.Dispose();
+                client?.Dispose();
+                server = null;
+                client = null;
             }
         }
         private void ParseResponse(byte[] buffer)

--- a/XPlaneConnector/XPlaneConnectorCore/XPlaneConnector.cs
+++ b/XPlaneConnector/XPlaneConnectorCore/XPlaneConnector.cs
@@ -28,7 +28,7 @@ namespace XPlaneConnectorCore
     public class XPlaneConnector : IXPlaneConnector
     {
         private UdpClient server;
-        private readonly UdpClient client;
+        private UdpClient client;
         private CancellationTokenSource ts;
         private Task listenTask;
         private Task observerTask;
@@ -85,6 +85,11 @@ namespace XPlaneConnectorCore
 
                 foreach (var dr in DataRefs.Values)
                     await UnsubscribeAsync(dr.DataRef);
+
+                server?.Dispose();
+                client?.Dispose();
+                server = null;
+                client = null;
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure XPlaneConnectorCore's StopAsync disposes UDP client and server
- release UDP resources in legacy connector Stop implementation

## Testing
- `dotnet build XPlaneConnector/XPlaneConnector.sln` *(fails: command not found)*
- `./XPlaneConnector/XPlaneConnectorExample/bin/Debug/XPlaneConnectorExample.exe` *(fails: Permission denied)*
- `netstat -anu` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a5e016148330b77380e86c12a1cc