### PR TITLE
Fix packet order of unsubscribe function

### DIFF
--- a/XPlaneConnector/XPlaneConnector/XPlaneConnector.cs
+++ b/XPlaneConnector/XPlaneConnector/XPlaneConnector.cs
@@ -292,8 +292,8 @@ namespace XPlaneConnector
             {
                 var dg = new XPDatagram();
                 dg.Add("RREF");
-                dg.Add(dr.Id);
                 dg.Add(0);
+                dg.Add(dr.Id);
                 dg.Add(dataref);
                 dg.FillTo(413);
 
@@ -401,3 +401,4 @@ namespace XPlaneConnector
         }
     }
 }
+


### PR DESCRIPTION
the id and frequency of dataref was put in different order in RREF packet of unsubscribe.

before(original, wrong): RREF + \0 + id + frequency + dataref name + \0
after(corrected): RREF + \0 + frequency + id + dataref name + \0
